### PR TITLE
Summary to table, and Related Recipes to bottom + Small improvements

### DIFF
--- a/lib/screens/recipe_screen.dart
+++ b/lib/screens/recipe_screen.dart
@@ -21,6 +21,8 @@ class RecipeScreen extends StatefulWidget {
 class _RecipeScreenState extends State<RecipeScreen> {
   final String spoonacularApiKey = dotenv.env['SPOONACULAR_API_KEY']!;
   late Map<String, dynamic> _recipe = {};
+  late Map<String, String> _recipeSummary = {};
+  late List<String> _relatedRecipes = [];
   bool _isLoading = true;
   bool _isError = false;
 
@@ -35,6 +37,8 @@ class _RecipeScreenState extends State<RecipeScreen> {
         final data = jsonDecode(response.body);
         setState(() {
           _recipe = data;
+          _recipeSummary = _buildSummaryInfo(_recipe['summary']);
+          _relatedRecipes = _separateRelatedRecipes(_recipe['summary']);
           _isLoading = false;
           _isError = false;
         });
@@ -60,6 +64,56 @@ class _RecipeScreenState extends State<RecipeScreen> {
         _isError = true;
       });
     }
+  }
+
+  // ignore: todo
+  // TODO: convert this to just use the following as Nutrition Facts:
+  // https://spoonacular.com/food-api/docs#Nutrition-by-ID
+  Map<String, String> _buildSummaryInfo(String payload) {
+    Map<String, String> nutritionData = {};
+    List<String> matchers = [
+      'protein',
+      'fat',
+      'calories',
+      '\$',
+      'cents',
+      'score',
+      'dairy',
+      'gluten',
+      'keto'
+    ];
+    final regex = RegExp(r'<b>(.*?)<\/b>');
+    final matches = regex.allMatches(payload);
+
+    for (Match match in matches) {
+      if (match.group(1) != null) {
+        String? text = match.group(1);
+
+        // If regex matches, then add that to map, and use
+        // 'matchers' index as the key
+        if (matchers.any((keyword) => text!.contains(keyword))) {
+          nutritionData[matchers[matchers
+              .indexWhere((keyword) => text!.contains(keyword))]] = text!;
+        }
+      }
+    }
+
+    return nutritionData;
+  }
+
+  // Using regex again to avoid an extra API call
+  List<String> _separateRelatedRecipes(String payload) {
+    List<String> relatedRecipes = [];
+    final regex = RegExp(r'<a(.*?)<\/a>');
+    final matches = regex.allMatches(payload);
+
+    for (Match match in matches) {
+      if (match.group(1) != null) {
+        relatedRecipes.add(match.group(1)!);
+      }
+    }
+
+    return relatedRecipes;
   }
 
   @override
@@ -119,17 +173,55 @@ class _RecipeScreenState extends State<RecipeScreen> {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
-                              _recipe['title'],
-                              style: Theme.of(context).textTheme.headlineMedium,
+                            Center(
+                              child: Text(
+                                _recipe['title'],
+                                style:
+                                    Theme.of(context).textTheme.headlineMedium,
+                              ),
                             ),
                             const SizedBox(height: 16),
-                            Html(
-                              data: _recipe['summary'],
-                              style: {
-                                'fontFamily': Style(fontFamily: 'Open Sans'),
-                                'fontSize': Style(fontSize: const FontSize(16)),
-                              },
+                            // Html(
+                            //   data: _recipe['summary'],
+                            //   style: {
+                            //     'fontFamily': Style(fontFamily: 'Open Sans'),
+                            //     'fontSize': Style(fontSize: const FontSize(16)),
+                            //   },
+                            // ),
+                            // const SizedBox(height: 16),
+                            Column(
+                              children: [
+                                Text(
+                                  'Summary',
+                                  style: Theme.of(context).textTheme.titleLarge,
+                                ),
+                                Center(
+                                  child: SizedBox(
+                                      child: DataTable(
+                                    columns: const [
+                                      DataColumn(label: Text('')),
+                                      DataColumn(label: Text('')),
+                                    ],
+                                    rows: _recipeSummary.entries
+                                        .map(
+                                          (entry) => DataRow(
+                                            cells: [
+                                              DataCell(Text(entry.key
+                                                              .toLowerCase() ==
+                                                          'cents' ||
+                                                      entry.key.toLowerCase() ==
+                                                          '\$'
+                                                  ? 'PRICE'
+                                                  : entry.key.toUpperCase())),
+                                              DataCell(Text(
+                                                  entry.value.toUpperCase())),
+                                            ],
+                                          ),
+                                        )
+                                        .toList(),
+                                  )),
+                                ),
+                              ],
                             ),
                             const SizedBox(height: 16),
                             Column(
@@ -138,65 +230,54 @@ class _RecipeScreenState extends State<RecipeScreen> {
                                   'Ingredients',
                                   style: Theme.of(context).textTheme.titleLarge,
                                 ),
-                                Container(
+                                SizedBox(
                                   height: 400,
-                                  decoration: BoxDecoration(
-                                    border: Border.all(
-                                      color: Colors.black,
-                                      width: 1,
-                                    ),
-                                    borderRadius: BorderRadius.circular(5),
-                                  ),
-                                  child: Expanded(
-                                    child: ListView.builder(
-                                      itemCount:
-                                          _recipe['extendedIngredients'].length,
-                                      itemBuilder:
-                                          (BuildContext context, int index) {
-                                        var ingredient =
-                                            _recipe['extendedIngredients']
-                                                [index];
-                                        final hasImage =
-                                            ingredient.containsKey('image');
-                                        return Padding(
-                                          padding: const EdgeInsets.symmetric(
-                                            vertical: 2.0,
+                                  child: ListView.builder(
+                                    itemCount:
+                                        _recipe['extendedIngredients'].length,
+                                    itemBuilder:
+                                        (BuildContext context, int index) {
+                                      var ingredient =
+                                          _recipe['extendedIngredients'][index];
+                                      final hasImage =
+                                          ingredient.containsKey('image');
+                                      return Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                            vertical: 2.0),
+                                        child: ListTile(
+                                          leading: hasImage
+                                              ? CircleAvatar(
+                                                  backgroundImage: NetworkImage(
+                                                      'https://spoonacular.com/cdn/ingredients_100x100/${ingredient['image']}'),
+                                                )
+                                              : null,
+                                          title: Column(
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
+                                            children: [
+                                              Text(
+                                                ingredient['name'],
+                                                style: Theme.of(context)
+                                                    .textTheme
+                                                    .titleMedium,
+                                              ),
+                                            ],
                                           ),
-                                          child: ListTile(
-                                            leading: hasImage
-                                                ? CircleAvatar(
-                                                    backgroundImage: NetworkImage(
-                                                        'https://spoonacular.com/cdn/ingredients_100x100/${ingredient['image']}'),
-                                                  )
-                                                : null,
-                                            title: Column(
-                                              crossAxisAlignment:
-                                                  CrossAxisAlignment.start,
-                                              children: [
-                                                Text(
-                                                  ingredient['name'],
-                                                  style: Theme.of(context)
-                                                      .textTheme
-                                                      .titleMedium,
-                                                ),
-                                              ],
-                                            ),
-                                            subtitle: Column(
-                                              crossAxisAlignment:
-                                                  CrossAxisAlignment.start,
-                                              children: [
-                                                Text(
-                                                  ingredient['original'],
-                                                  style: Theme.of(context)
-                                                      .textTheme
-                                                      .bodySmall,
-                                                ),
-                                              ],
-                                            ),
+                                          subtitle: Column(
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
+                                            children: [
+                                              Text(
+                                                ingredient['original'],
+                                                style: Theme.of(context)
+                                                    .textTheme
+                                                    .bodySmall,
+                                              ),
+                                            ],
                                           ),
-                                        );
-                                      },
-                                    ),
+                                        ),
+                                      );
+                                    },
                                   ),
                                 ),
                               ],
@@ -224,15 +305,24 @@ class _RecipeScreenState extends State<RecipeScreen> {
                                         child: SizedBox(
                                           height: 500,
                                           child: ListView.builder(
-                                            itemCount:
-                                                _recipe['analyzedInstructions']
+                                            itemCount: _recipe[
+                                                            'analyzedInstructions']
+                                                        .toString() ==
+                                                    '[]'
+                                                ? 0
+                                                : _recipe['analyzedInstructions']
                                                         [0]['steps']
                                                     .length,
                                             itemBuilder: (BuildContext context,
                                                 int index) {
-                                              final step = _recipe[
-                                                      'analyzedInstructions'][0]
-                                                  ['steps'][index];
+                                              final step =
+                                                  _recipe['analyzedInstructions']
+                                                              .toString() ==
+                                                          '[]'
+                                                      ? 'N/A'
+                                                      : _recipe[
+                                                              'analyzedInstructions']
+                                                          [0]['steps'][index];
                                               return ListTile(
                                                 leading: CircleAvatar(
                                                   child: Text(
@@ -258,6 +348,35 @@ class _RecipeScreenState extends State<RecipeScreen> {
                                 ),
                               ],
                             ),
+                            const SizedBox(height: 16),
+                            Column(
+                              children: [
+                                Text(
+                                  'Related Recipes:',
+                                  style: Theme.of(context).textTheme.titleLarge,
+                                ),
+                                Container(
+                                  height: 250,
+                                  child: ListView.builder(
+                                    itemCount: _relatedRecipes.length,
+                                    itemBuilder: (context, index) {
+                                      return ListTile(
+                                        title: Html(
+                                          data:
+                                              '<a${_relatedRecipes[index]!}</a>',
+                                          style: {
+                                            'fontFamily':
+                                                Style(fontFamily: 'Open Sans'),
+                                            'fontSize': Style(
+                                                fontSize: const FontSize(16)),
+                                          },
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                )
+                              ],
+                            )
                           ],
                         ),
                       )


### PR DESCRIPTION
Other branch on local was being wonky so made this one instead. Other branch commit history:
- Use SizedBox instead of Container for ParentDataWidget error
- Comment summary and move related recipes to bottom
- Grab bolded elements in summary to table
- Handle when instructions are empty

![2A2C6ED5-2F08-4E23-93EF-725BB43DAC8B](https://user-images.githubusercontent.com/55364674/229540233-2e39a050-20fe-4a79-a692-59fd24928e68.jpeg)
![03FC8D69-1E54-46EF-A297-29BCF36DB13E](https://user-images.githubusercontent.com/55364674/229540238-4ef06142-d475-4e8d-a928-b0ea2ae0c8de.jpeg)
